### PR TITLE
Add power iteration accuracy tests with minor stability fixes for power iteration

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -24,6 +24,8 @@ def extra_args(parser):
                         help='power iteration momentum term')
     parser.add_argument('--num_steps', default=20, type=int,
                         help='number of power iter steps')
+    parser.add_argument('--cuda', action='store_true',
+                        help='if true, use CUDA/GPUs')
 
 
 def main(args):
@@ -38,7 +40,8 @@ def main(args):
                                                        criterion,
                                                        args.num_eigenthings,
                                                        args.num_steps,
-                                                       momentum=args.momentum)
+                                                       momentum=args.momentum,
+                                                       use_gpu=args.cuda)
     print("Eigenvecs:")
     print(eigenvecs)
     print("Eigenvals:")

--- a/hessian_eigenthings/power_iter.py
+++ b/hessian_eigenthings/power_iter.py
@@ -63,7 +63,7 @@ def deflated_power_iteration(operator,
         def _new_op_fn(x, op=current_op, val=eigenval, vec=eigenvec):
             return op.apply(x) - _deflate(x, val, vec)
         current_op = LambdaOperator(_new_op_fn, operator.size)
-        eigenvals.append(eigenval.item())
+        eigenvals.append(eigenval)
         eigenvecs.append(eigenvec.cpu())
 
     return eigenvals, eigenvecs
@@ -88,7 +88,7 @@ def power_iteration(operator, steps=20, error_threshold=1e-4,
         new_vec = operator.apply(vec) - momentum * prev_vec
         prev_vec = vec / torch.norm(vec)
 
-        lambda_estimate = vec.dot(new_vec)
+        lambda_estimate = vec.dot(new_vec).item()
         diff = lambda_estimate - prev_lambda
         vec = new_vec.detach() / torch.norm(new_vec)
         error = np.abs(diff / lambda_estimate)

--- a/hessian_eigenthings/power_iter.py
+++ b/hessian_eigenthings/power_iter.py
@@ -50,6 +50,7 @@ def deflated_power_iteration(operator,
     eigenvals = []
     eigenvecs = []
     current_op = operator
+    prev_vec = None
 
     def _deflate(x, val, vec):
         return val * vec.dot(x) * vec
@@ -58,11 +59,13 @@ def deflated_power_iteration(operator,
         eigenval, eigenvec = power_iteration(current_op, power_iter_steps,
                                              power_iter_err_threshold,
                                              momentum=momentum,
-                                             use_gpu=use_gpu)
+                                             use_gpu=use_gpu,
+                                             init_vec=prev_vec)
 
         def _new_op_fn(x, op=current_op, val=eigenval, vec=eigenvec):
             return op.apply(x) - _deflate(x, val, vec)
         current_op = LambdaOperator(_new_op_fn, operator.size)
+        prev_vec = eigenvec
         eigenvals.append(eigenval)
         eigenvecs.append(eigenvec.cpu())
 
@@ -70,7 +73,8 @@ def deflated_power_iteration(operator,
 
 
 def power_iteration(operator, steps=20, error_threshold=1e-4,
-                    momentum=0.0, use_gpu=True):
+                    momentum=0.0, use_gpu=True,
+                    init_vec=None):
     """
     Compute dominant eigenvalue/eigenvector of a matrix
     operator: linear Operator giving us matrix-vector product access
@@ -78,7 +82,11 @@ def power_iteration(operator, steps=20, error_threshold=1e-4,
     returns: (principal eigenvalue, principal eigenvector) pair
     """
     vector_size = operator.size  # input dimension of operator
-    vec = torch.rand(vector_size)
+    if init_vec is None:
+        vec = torch.rand(vector_size)
+    else:
+        vec = init_vec
+
     if use_gpu:
         vec = vec.cuda()
 

--- a/hessian_eigenthings/power_iter.py
+++ b/hessian_eigenthings/power_iter.py
@@ -94,7 +94,7 @@ def power_iteration(operator, steps=20, error_threshold=1e-4,
     prev_vec = torch.zeros_like(vec)
     for _ in range(steps):
         new_vec = operator.apply(vec) - momentum * prev_vec
-        prev_vec = vec / torch.norm(vec)
+        prev_vec = vec / (torch.norm(vec) + 1e-6)
 
         lambda_estimate = vec.dot(new_vec).item()
         diff = lambda_estimate - prev_lambda

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ setup(name="hessian_eigenthings",
       author="Noah Golmant",
       install_requires=install_requires,
       packages=find_packages(),
-      description='Eigendecomposition of model Hessians in PyTorch!')
+      description='Eigendecomposition of model Hessians in PyTorch!',
+      version='0.0.1')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,50 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+def compute_eigenvec_cos_similarity(actual, estimated):
+    scores = []
+    for estimate in estimated:
+        score = np.abs(np.dot(actual, estimate))
+        scores.append(score)
+    return scores
+
+
+def plot_eigenval_estimates(estimates, label):
+    """
+    estimates = 2D array (num_trials x num_eigenvalues)
+
+    x-axis = eigenvalue index
+    y-axis = eigenvalue estimate
+    """
+    if len(estimates.shape) == 1:
+        var = np.zeros_like(estimates)
+    else:
+        var = np.var(estimates, axis=0)
+    y = np.mean(estimates, axis=0)
+    x = list(range(len(y)))
+    error = np.sqrt(var)
+    plt.plot(x, y, label=label)
+    plt.fill_between(x, y-error, y+error, alpha=.2)
+
+
+def plot_eigenvec_errors(true, estimates, label):
+    """
+    plots error for all eigenvector estimates in L2 norm
+    estimates = (num_trials x num_eigenvalues x num_params)
+    true = (num_eigenvalues x num_params)
+    """
+    diffs = []
+    num_eigenvals = true.shape[0]
+    for i in range(num_eigenvals):
+        cur_estimates = estimates[:, i, :]
+        cur_eigenvec = true[i]
+        diff = compute_eigenvec_cos_similarity(cur_eigenvec, cur_estimates)
+        diffs.append(diff)
+    diffs = np.array(diffs).T
+    var = np.var(diffs, axis=0)
+    y = np.mean(diffs, axis=0)
+    x = list(range(len(y)))
+
+    error = np.sqrt(var)
+    plt.plot(x, y, label=label)
+    plt.fill_between(x, y-error, y+error, alpha=.2)

--- a/tests/variance_tests.py
+++ b/tests/variance_tests.py
@@ -99,7 +99,8 @@ def test_full_hessian(model, criterion, x, y, ntrials=10):
             criterion,
             num_eigenthings=nparams,
             power_iter_steps=100,
-            power_iter_err_threshold=1e-10,
+            power_iter_err_threshold=1e-5,
+            momentum=0,
             use_gpu=False)
         est_eigenvals = np.array(est_eigenvals)
         est_eigenvecs = np.array([t.numpy() for t in est_eigenvecs])
@@ -115,6 +116,7 @@ def test_full_hessian(model, criterion, x, y, ntrials=10):
     # Plot eigenvalue error
     plt.subplot(1, 2, 1)
     plt.title('Eigenvalue errors')
+    plt.ylim(-10, 10)
     plt.plot(list(range(nparams)), real_eigenvals, label='True Eigenvals')
     plot_eigenval_estimates(eigenvals, label='%d trials' % ntrials)
     plt.legend()
@@ -127,10 +129,10 @@ def test_full_hessian(model, criterion, x, y, ntrials=10):
 
 
 if __name__ == '__main__':
-    indim = 5
+    indim = 10
     outdim = 1
-    nsamples = 10
-    ntrials = 100
+    nsamples = 100
+    ntrials = 50
 
     model = torch.nn.Linear(indim, outdim)
     criterion = torch.nn.MSELoss()

--- a/tests/variance_tests.py
+++ b/tests/variance_tests.py
@@ -1,0 +1,141 @@
+"""
+This test looks at the variance of eigenvalue/eigenvector estimates
+    (1) Full dataset should have deterministic results
+    (2) Compute variance of repeated trials and the effect of averaging, error
+        relative to full dataset
+    (3) Compute variance of full power iteration on a fixed mini-batch (vs.
+        varying the mini-batch at each step) compared to full dataset
+"""
+
+import numpy as np
+import torch
+from hessian_eigenthings import compute_hessian_eigenthings
+
+from torch.utils.data import DataLoader
+import matplotlib.pyplot as plt
+
+
+def compute_eigenvec_cos_similarity(actual, estimated):
+    scores = []
+    for estimate in estimated:
+        score = np.abs(np.dot(actual, estimate))
+        scores.append(score)
+    return scores
+
+
+def plot_eigenval_estimates(estimates, label):
+    """
+    estimates = 2D array (num_trials x num_eigenvalues)
+
+    x-axis = eigenvalue index
+    y-axis = eigenvalue estimate
+    """
+    if len(estimates.shape) == 1:
+        var = np.zeros_like(estimates)
+    else:
+        var = np.var(estimates, axis=0)
+    y = np.mean(estimates, axis=0)
+    x = list(range(len(y)))
+    plt.errorbar(x, y, np.sqrt(var), marker='^', label=label)
+
+
+def plot_eigenvec_errors(true, estimates, label):
+    """
+    plots error for all eigenvector estimates in L2 norm
+    estimates = (num_trials x num_eigenvalues x num_params)
+    true = (num_eigenvalues x num_params)
+    """
+    diffs = []
+    num_eigenvals = true.shape[0]
+    for i in range(num_eigenvals):
+        cur_estimates = estimates[:, i, :]
+        cur_eigenvec = true[i]
+        diff = compute_eigenvec_cos_similarity(cur_eigenvec, cur_estimates)
+        diffs.append(diff)
+    diffs = np.array(diffs).T
+    var = np.var(diffs, axis=0)
+    y = np.mean(diffs, axis=0)
+    x = list(range(len(y)))
+
+    plt.errorbar(x, y, np.sqrt(var), marker='^', label=label)
+
+
+def get_full_hessian(loss_grad, model):
+    # from https://discuss.pytorch.org/t/compute-the-hessian-matrix-of-a-network/15270/3
+    cnt = 0
+    for g in loss_grad:
+        g_vector = g.contiguous().view(-1) if cnt == 0 else torch.cat([g_vector, g.contiguous().view(-1)])
+        cnt = 1
+    l = g_vector.size(0)
+    hessian = torch.zeros(l, l)
+    for idx in range(l):
+        grad2rd = torch.autograd.grad(g_vector[idx], model.parameters(), create_graph=True)
+        cnt = 0
+        for g in grad2rd:
+            g2 = g.contiguous().view(-1) if cnt == 0 else torch.cat([g2, g.contiguous().view(-1)])
+            cnt = 1
+        hessian[idx] = g2
+    return hessian.cpu().data.numpy()
+
+
+def test_full_hessian(model, criterion, x, y, ntrials=10):
+    loss = criterion(model(x), y)
+    loss_grad = torch.autograd.grad(loss, model.parameters(), create_graph=True)
+    real_hessian = get_full_hessian(loss_grad, model)
+
+    samples = [(x_i, y_i) for x_i, y_i in zip(x, y)]
+    # full dataset
+    dataloader = DataLoader(samples, batch_size=len(x))
+
+    eigenvals = []
+    eigenvecs = []
+
+    nparams = len(real_hessian)
+
+    for _ in range(ntrials):
+        est_eigenvals, est_eigenvecs = compute_hessian_eigenthings(
+            model,
+            dataloader,
+            criterion,
+            num_eigenthings=nparams,
+            power_iter_steps=100,
+            power_iter_err_threshold=1e-10,
+            use_gpu=False)
+        est_eigenvals = np.array(est_eigenvals)
+        est_eigenvecs = np.array([t.numpy() for t in est_eigenvecs])
+
+        eigenvals.append(est_eigenvals)
+        eigenvecs.append(est_eigenvecs)
+
+    eigenvals = np.array(eigenvals)
+    eigenvecs = np.array(eigenvecs)
+
+    real_eigenvals, real_eigenvecs = np.linalg.eig(real_hessian)
+
+    # Plot eigenvalue error
+    plt.subplot(1, 2, 1)
+    plt.title('Eigenvalue errors')
+    plt.plot(list(range(nparams)), real_eigenvals, label='True Eigenvals')
+    plot_eigenval_estimates(eigenvals, label='%d trials' % ntrials)
+    plt.legend()
+    # Plot eigenvector L2 norm error
+    plt.subplot(1, 2, 2)
+    plt.title('Eigenvector cos simliarity')
+    plot_eigenvec_errors(real_eigenvecs, eigenvecs, label='%d trials' % ntrials)
+    plt.legend()
+    plt.show()
+
+
+if __name__ == '__main__':
+    indim = 5
+    outdim = 1
+    nsamples = 10
+    ntrials = 100
+
+    model = torch.nn.Linear(indim, outdim)
+    criterion = torch.nn.MSELoss()
+
+    x = torch.rand((nsamples, indim))
+    y = torch.rand((nsamples, outdim))
+
+    test_full_hessian(model, criterion, x, y, ntrials=ntrials)


### PR DESCRIPTION
This adds tests for
1. Power iteration on random PSD Wishart matrices
2. Power iteration using the full dataset for simple linear models
3. Power iteration using a fixed mini-batch
4. Stochastic power iteration using a new mini-batch for each hessian-vector product evaluation

Plots can be found in #23.