### PR TITLE
Handle output of huggingface models with optional logits attribute

### DIFF
--- a/hessian_eigenthings/hvp_operator.py
+++ b/hessian_eigenthings/hvp_operator.py
@@ -131,6 +131,7 @@ class HVPOperator(Operator):
                 target = target.cuda()
 
             output = self.model(input)
+            output = output.logits if hasattr(output, 'logits') else output
             loss = self.criterion(output, target)
             grad_dict = torch.autograd.grad(
                 loss, self.model.parameters(), create_graph=True


### PR DESCRIPTION
For huggingface models usually we need to get "logits". The output itself cannot be used for loss computation.